### PR TITLE
Guilded.gg Webhook Validation

### DIFF
--- a/app/Model/Pathfinder/MapModel.php
+++ b/app/Model/Pathfinder/MapModel.php
@@ -396,7 +396,7 @@ class MapModel extends AbstractMapTrackingModel {
         if( !empty($val) ){
             $hosts = [
                 'slack' => ['hooks.slack.com'],
-                'discord' => ['discordapp.com', 'ptb.discordapp.com']
+                'discord' => ['discordapp.com', 'ptb.discordapp.com', 'media.guilded.gg'] //Forced Guilded webhook
             ];
 
             if(


### PR DESCRIPTION
Allows guilded.gg URL to pass as a Discord webhook.